### PR TITLE
Add start script for project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ ! -f ./backend/.env ]; then
+    echo "env file missing"
+    exit 1
+fi
+
+docker-compose up


### PR DESCRIPTION
Script checks for the .env file, if missing the project won't start.